### PR TITLE
fix(client): truncate User-Agent to prevent device column overflow (PRACTICKET-23)

### DIFF
--- a/src/main/java/com/practicket/client/component/ClientInfoExtractor.java
+++ b/src/main/java/com/practicket/client/component/ClientInfoExtractor.java
@@ -13,15 +13,18 @@ public class ClientInfoExtractor {
     private static final String DEVICE_KEY = "User-Agent";
     private static final String SOURCE_URL_KEY = "Referer";
 
+    // client 테이블 ip/device/referer 컬럼은 VARCHAR(255). 초과 입력 시 Data truncation 으로 INSERT 실패하므로 저장 전 절단한다. (PRACTICKET-23)
+    private static final int COLUMN_MAX_LENGTH = 255;
+
     public ClientRequestInfo extractClientInfo(HttpServletRequest request) {
         String ip = this.extractClientIp(request);
         String device = this.extractClientDevice(request);
         String sourceUrl = this.extractClientReferer(request);
 
         return ClientRequestInfo.builder()
-                .ip(ip)
-                .device(device)
-                .sourceUrl(sourceUrl)
+                .ip(truncate(ip))
+                .device(truncate(device))
+                .sourceUrl(truncate(sourceUrl))
                 .build();
     }
 
@@ -43,5 +46,12 @@ public class ClientInfoExtractor {
 
     private String extractClientReferer(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(SOURCE_URL_KEY)).orElse("Unknown");
+    }
+
+    private String truncate(String value) {
+        if (value != null && value.length() > COLUMN_MAX_LENGTH) {
+            return value.substring(0, COLUMN_MAX_LENGTH);
+        }
+        return value;
     }
 }


### PR DESCRIPTION
## 🔴 Sentry 자동 수정 — PRACTICKET-23

> 🤖 이 PR은 **Sentry → 원인분석 파이프라인**이 자동 생성했습니다. 리뷰 후 머지하세요 (auto-merge 비활성).

| | |
|---|---|
| **이슈** | `DataIntegrityViolationException` · `POST /api/client` |
| **환경** | prod · pod `practicket-69ff857f9d-ww69v` |
| **영향** | 누적 **725건 / 63명** |
| **Sentry** | https://practicket.sentry.io/issues/6876816145/ |

### 근본 원인
`User-Agent` 헤더 값을 `client.device`(VARCHAR 255) 컬럼에 길이 검증 없이 저장합니다.
255자를 넘는 User-Agent 요청이 오면 MySQL이 `Data too long for column 'device'` 로 거부 →
`DataIntegrityViolationException` → `GlobalExceptionHandler` 일반 핸들러 → **HTTP 500**.
`ip`(X-Forwarded-For), `referer`(Referer) 도 동일한 VARCHAR(255) 패턴이라 같은 위험을 가집니다.

```
MysqlDataTruncation: Data too long for column 'device' at row 1
  at ClientManager.create(ClientManager.java:35)
  at ClientService.create(ClientService.java:25)
  at ClientController.create(ClientController.java:29)
```

### 변경 사항
- `ClientInfoExtractor`: `ip` / `device` / `referer` 값을 저장 전 컬럼 길이(255)로 절단하는 `truncate()` 추가
- DB 마이그레이션 불필요 (기존 스키마 유지)

### 검증
- [x] `./gradlew compileJava` 통과 (자동 파이프라인 수행)
- [ ] `./gradlew build` (테스트 포함) — CI에서 수행
- [ ] 사람 리뷰 (auto-merge 안 함)

### 후속 제안 (별도 이슈)
- `DataIntegrityViolationException` 을 `GlobalExceptionHandler`에서 400대로 명시 처리 → 500/Sentry 노이즈 감소
- 데이터 보존이 중요하면 `device` 컬럼을 `TEXT`/`VARCHAR(512)` 로 확장 검토
