### PR TITLE
fix: User-Agent 헤더 255자 초과 시 device 컬럼 데이터 잘림 오류 수정

### DIFF
--- a/src/main/java/com/practicket/client/component/ClientInfoExtractor.java
+++ b/src/main/java/com/practicket/client/component/ClientInfoExtractor.java
@@ -33,10 +33,15 @@ public class ClientInfoExtractor {
         return request.getRemoteAddr();
     }
 
+    private static final int DEVICE_MAX_LENGTH = 255;
+
     private String extractClientDevice(HttpServletRequest request) {
         String userAgent = request.getHeader(DEVICE_KEY);
         if (userAgent == null) {
-            userAgent = "Unknown Device";
+            return "Unknown Device";
+        }
+        if (userAgent.length() > DEVICE_MAX_LENGTH) {
+            return userAgent.substring(0, DEVICE_MAX_LENGTH);
         }
         return userAgent;
     }


### PR DESCRIPTION
## 변경 사항
- `ClientInfoExtractor`에서 `User-Agent`(device) 값을 저장 전 255자로 절단

## 배경
`POST /api/client` 에서 `User-Agent` 헤더를 `client.device`(VARCHAR 255) 컬럼에 길이 검증 없이 저장하여, 255자를 초과하는 요청에서 `Data too long for column device` → `DataIntegrityViolationException` → HTTP 500이 발생했습니다. (Sentry PRACTICKET-23 · prod 6,547건 / 63명 영향)
컬럼 길이에 맞춰 절단하여 방어하며, DB 스키마 변경은 불필요합니다.

Sentry: https://practicket.sentry.io/issues/6876816145/
