### PR TITLE
fix: 분 경계 근처 발급 시 티켓 토큰 즉시 만료 버그 수정

### DIFF
--- a/src/main/java/com/practicket/ticket/component/TicketTokenManager.java
+++ b/src/main/java/com/practicket/ticket/component/TicketTokenManager.java
@@ -28,12 +28,19 @@ public class TicketTokenManager {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
+    private static final long MIN_TTL_SECONDS = 30;
+
     public TicketToken issue(String clientKey) {
         Instant issuedAt = Instant.now();
         Instant expiresAt = issuedAt
                 .plus(1, ChronoUnit.MINUTES)
                 .truncatedTo(ChronoUnit.MINUTES)
                 .minusSeconds(10);
+
+        // 잔여 TTL이 너무 짧으면(30초 미만) 1분 앞으로 이동
+        if (Duration.between(issuedAt, expiresAt).getSeconds() < MIN_TTL_SECONDS) {
+            expiresAt = expiresAt.plus(1, ChronoUnit.MINUTES);
+        }
 
         long ttlSec = Duration.between(issuedAt, expiresAt).getSeconds();
         String jti = UUID.randomUUID().toString();
@@ -51,6 +58,7 @@ public class TicketTokenManager {
     public Claims parseAndValidate(String jwt) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey)
+                .setAllowedClockSkewSeconds(5)
                 .build()
                 .parseClaimsJws(jwt)
                 .getBody();


### PR DESCRIPTION
## 변경 사항
- `TicketTokenManager.issue()`: 계산된 TTL이 30초 미만이면 만료 시각을 1분 뒤로 이동
- `TicketTokenManager.parseAndValidate()`: JJWT `setAllowedClockSkewSeconds(5)` 추가

## 배경
Sentry 이슈 PRACTICKET-33 — `GET /reservation` 에서 `ExpiredJwtException` 이 840건, 545명에게 발생.

`issue()` 의 만료 시간 계산 로직이 분 경계 근처에서 TTL 0초 이하인 토큰을 발급했다.

```
expiresAt = (issuedAt + 1분).truncatedToMinutes() - 10초
```

예: `issuedAt = 06:43:50` → `expiresAt = 06:43:50` (TTL = 0초)
예: `issuedAt = 06:43:45` → `expiresAt = 06:43:50` (TTL = 5초)

이 상태에서 사용자가 예약 페이지를 요청하면 토큰이 이미 만료되어 있어 `ExpiredJwtException` 이 발생한다.