### PR TITLE
fix: JWT 검증 시 clock skew 허용 범위 5초 추가

### DIFF
--- a/src/main/java/com/practicket/ticket/component/TicketTokenManager.java
+++ b/src/main/java/com/practicket/ticket/component/TicketTokenManager.java
@@ -51,6 +51,7 @@ public class TicketTokenManager {
     public Claims parseAndValidate(String jwt) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey)
+                .setAllowedClockSkewSeconds(5)
                 .build()
                 .parseClaimsJws(jwt)
                 .getBody();


### PR DESCRIPTION
## 변경 사항
- `TicketTokenManager.parseAndValidate()`의 JWT 파서에 `setAllowedClockSkewSeconds(5)` 추가

## 배경
Sentry 이슈 PRACTICKET-34: `POST /api/ticket` 엔드포인트에서 `ExpiredJwtException`이 393회 발생하여 186명의 사용자에게 영향. JWT 만료 시각과 서버 현재 시각의 차이가 142ms에 불과하지만 허용 clock skew가 0ms로 설정되어 있어 서버 간 미세한 시각 차이만으로도 유효한 토큰이 거부됨.