### PR TITLE
fix: ArtUpdateRequest에서 알 수 없는 JSON 필드 무시 처리

### DIFF
--- a/src/main/java/com/practicket/art/dto/ArtUpdateRequest.java
+++ b/src/main/java/com/practicket/art/dto/ArtUpdateRequest.java
@@ -1,10 +1,12 @@
 package com.practicket.art.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ArtUpdateRequest {
 
     @NotBlank(message = "제목을 입력해주세요.")


### PR DESCRIPTION
## 변경 사항
- `ArtUpdateRequest`에 `@JsonIgnoreProperties(ignoreUnknown = true)` 어노테이션 추가

## 배경
Sentry 이슈 PRACTICKET-4T: `PUT /api/arts/{artId}` 엔드포인트에서 클라이언트가 `width` 등 DTO에 정의되지 않은 필드를 포함해 요청을 보낼 경우, Jackson이 `UnrecognizedPropertyException`을 발생시켜 `HttpMessageNotReadableException`(HTTP 400)으로 이어지는 문제가 발생하였다. 9회 발생, 4명의 사용자에게 영향을 미쳤다. `ArtUpdateRequest`에는 `title`, `pixelData` 두 필드만 정의되어 있으며, 글로벌 `JacksonConfig`에 알 수 없는 필드 무시 옵션이 설정되어 있지 않아 클라이언트가 추가 필드를 보낼 때마다 요청이 실패하였다.