### PR TITLE
fix: 욕설 필터 API 타임아웃을 500ms로 제한하여 채팅 지연 방지

### DIFF
--- a/src/main/java/com/practicket/api/profanity/ProfanityApiClient.java
+++ b/src/main/java/com/practicket/api/profanity/ProfanityApiClient.java
@@ -7,10 +7,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 @Component
 public class ProfanityApiClient {
 
     private final WebClient webClient;
+
+    private static final Duration TIMEOUT = Duration.ofMillis(500);
 
     public ProfanityApiClient(WebClient.Builder webClientBuilder, @Value("${api.profanity.url}") String baseUrl) {
         this.webClient = webClientBuilder.baseUrl(baseUrl).build();
@@ -22,6 +26,7 @@ public class ProfanityApiClient {
                 .uri("/")
                 .bodyValue(request)
                 .retrieve()
-                .bodyToMono(ValidationResponse.class);
+                .bodyToMono(ValidationResponse.class)
+                .timeout(TIMEOUT);
     }
 }


### PR DESCRIPTION
## 변경 사항
- `ProfanityApiClient.validate()`에 `.timeout(Duration.ofMillis(500))` 추가

## 배경
Sentry 이슈 PRACTICKET-5C: `POST /api/chat` 엔드포인트에서 욕설 필터 API(`profanity-filter-api.practicket.svc.cluster.local`) 호출 시 `ReadTimeoutException`이 발생해 154건, 29명 사용자에게 영향을 줬습니다.

`WebClientConfig`에 설정된 전역 `responseTimeout`(3초)이 그대로 적용되어 API가 응답하지 않을 때 채팅 요청이 매번 3초씩 블로킹됐습니다. 욕설 필터는 내부 K8s 서비스로 정상 시 응답이 빠르며, 실패 시에는 `ProfanityValidator`가 이미 fail-open으로 처리하므로 500ms 이내로 빠르게 실패해도 무방합니다.