### PR TITLE
fix: MalformedJwtException 발생 시 로그 레벨을 WARN으로 낮춰 Sentry 오탐 방지

### DIFF
--- a/src/main/java/com/practicket/ticket/application/TicketQueueService.java
+++ b/src/main/java/com/practicket/ticket/application/TicketQueueService.java
@@ -7,6 +7,7 @@ import com.practicket.ticket.infra.redis.TicketQueueRepository;
 import com.practicket.ticket.infra.redis.TicketTokenRepository;
 import com.practicket.ticket.infra.sse.TicketSseEmitterRepository;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -158,8 +159,11 @@ public class TicketQueueService {
 
             return expirationTime >= now;
 
+        } catch (JwtException e) {
+            log.warn("유효하지 않은 예약 토큰 요청: {}", e.getMessage());
+            return false;
         } catch (Exception e) {
-            log.error("Token validation failed", e);
+            log.error("예약 토큰 검증 중 예상치 못한 오류", e);
             return false;
         }
     }


### PR DESCRIPTION
## 변경 사항
- `TicketQueueService.isValidReservationToken`의 catch 블록을 `JwtException`과 그 외 예외로 분리
- `JwtException`(MalformedJwtException 포함)은 `log.warn`으로 기록하여 Sentry ERROR 오탐 방지
- 예상치 못한 예외는 기존처럼 `log.error`로 기록

## 배경
Sentry 이슈 PRACTICKET-58: `GET /reservation?token=<비JWT 문자열>` 요청 시 `MalformedJwtException`이 발생하고 있음. 해당 예외는 `isValidReservationToken` 내부에서 이미 catch되어 `false` 반환 후 `/`로 리다이렉트되므로 동작 자체는 정상이나, `log.error`로 기록되어 Sentry가 오류로 수집함. 잘못된 토큰 입력은 예상 가능한 사용자 입력 오류이므로 WARN 레벨이 적절하며, 3명의 사용자에게 발생한 알림 노이즈를 제거한다.