### PR TITLE
fix: Client token 컬럼에 unique 제약 추가로 findByToken 풀 스캔 해소

### DIFF
--- a/src/main/java/com/practicket/client/domain/Client.java
+++ b/src/main/java/com/practicket/client/domain/Client.java
@@ -22,7 +22,7 @@ public class Client {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String token;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 변경 사항
- `Client.token` 필드 `@Column` 어노테이션에 `unique = true` 추가

## 배경
Sentry 이슈 PRACTICKET-5M: `GET /api/captcha` 트랜잭션에서 `DataAccessResourceFailureException`이 발생하며 HikariPool-1 커넥션 풀 전체(10개)가 소진되고 190개 요청이 대기하는 장애가 확인됨.

근본 원인은 `Client.token` 컬럼에 인덱스가 없어 `clientRepository.findByToken(token)` 호출 시 매번 풀 테이블 스캔이 발생한다는 점이다. `/api/captcha`는 `@Auth` 어노테이션으로 인해 요청마다 해당 쿼리를 실행하며, 추가로 `captchaService.getStatistic()` 내부에서도 2회의 DB 쿼리가 발생한다. 풀 스캔으로 커넥션 보유 시간이 길어지고 커넥션 풀이 빠르게 고갈된다.

`unique = true`로 유니크 제약을 설정하면 Hibernate가 해당 컬럼에 유니크 인덱스를 생성하여 `findByToken` 조회를 O(n) 풀 스캔에서 O(log n) 인덱스 탐색으로 개선한다. 또한 token은 인증 키로 사용되므로 유니크 제약은 데이터 무결성 측면에서도 필수적이다.