### PR TITLE
fix: HikariCP 커넥션 풀 크기를 30으로 확장하여 커넥션 고갈 방지

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,13 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   jackson:
     property-naming-strategy: SNAKE_CASE
+  datasource:
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 server:
   servlet:
     session:


### PR DESCRIPTION
## 변경 사항
- `application.yml`에 HikariCP 커넥션 풀 설정 추가
- `maximum-pool-size`: 기본값 10 → 30으로 증가
- `minimum-idle`: 10으로 설정
- `connection-timeout`: 30,000ms (30초)
- `idle-timeout`: 600,000ms (10분)
- `max-lifetime`: 1,800,000ms (30분)

## 배경
Sentry 이슈 PRACTICKET-5P: `POST /api/client` 요청 처리 중 `CannotCreateTransactionException`이 발생했습니다.
원인은 HikariCP 커넥션 풀이 기본값(10)으로 설정되어 있어, 동시 트래픽이 몰렸을 때 `total=10, active=10, idle=0, waiting=191` 상태로 191개의 요청이 커넥션 획득 대기 중 타임아웃(30초)이 발생한 것입니다.
`application.yml`에 명시적인 HikariCP 설정이 없어 기본값이 적용되고 있었으며, 풀 크기를 30으로 확장하여 트래픽 급증 시에도 커넥션 고갈을 방지합니다.