### PR TITLE
fix: ChatService 클래스 레벨 @Transactional 제거로 커넥션 풀 고갈 방지

### DIFF
--- a/src/main/java/com/practicket/chat/application/ChatService.java
+++ b/src/main/java/com/practicket/chat/application/ChatService.java
@@ -13,7 +13,6 @@ import com.practicket.common.exception.ErrorCode;
 import com.practicket.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
@@ -22,7 +21,6 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ChatService {
 


### PR DESCRIPTION
## 변경 사항
- `ChatService`에서 클래스 레벨 `@Transactional` 어노테이션 제거
- 불필요한 `import org.springframework.transaction.annotation.Transactional` 제거

## 배경
Sentry 이슈 PRACTICKET-4F: `HikariPool-1 - Connection is not available, request timed out after 30000ms (total=10, active=10, idle=0, waiting=191)`

`ChatService`는 MongoDB(채팅 저장)와 Redis(메시지 발행)만 사용하며 RDBMS 작업이 전혀 없다. 그러나 클래스 레벨 `@Transactional`로 인해 `JpaTransactionManager`가 메서드 진입 시 HikariCP 커넥션을 즉시 획득한다(`autoCommit=false` 설정을 위해). `saveChat()`은 외부 욕설 필터 API(최대 3초 응답 대기)를 호출하는 동안 이 커넥션을 점유하고 있어, 동시 채팅 요청이 몰릴 경우 풀(기본값 10개)이 소진된다. 결과적으로 단순 DB INSERT만 필요한 `POST /api/client`를 포함한 모든 RDBMS 의존 요청이 30초 대기 후 타임아웃된다.