### PR TITLE
fix: GET /api/chat cursor 파라미터를 선택적으로 변경하여 MissingServletRequestParameterException 해소

### DIFF
--- a/src/main/java/com/practicket/chat/application/ChatController.java
+++ b/src/main/java/com/practicket/chat/application/ChatController.java
@@ -26,10 +26,13 @@ public class ChatController {
 
     @GetMapping
     public ResponseEntity<?> findAllChat(
-            @RequestParam("cursor")
+            @RequestParam(name = "cursor", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             LocalDateTime cursor
     ) {
+        if (cursor == null) {
+            cursor = LocalDateTime.now();
+        }
         List<ChatResponseDto> chats = chatService.findAllChat(cursor);
         return ResponseEntity.ok(chats);
     }


### PR DESCRIPTION
## 변경 사항
- `ChatController.findAllChat`의 `cursor` 파라미터를 `required = false`로 변경
- `cursor`가 null인 경우 `LocalDateTime.now()`를 기본값으로 사용하여 최신 50건 조회

## 배경
Sentry 이슈 PRACTICKET-22: `GET /api/chat` 요청 시 `cursor` 쿼리 파라미터를 전달하지 않으면 Spring이 `MissingServletRequestParameterException`을 발생시켜 클라이언트에 400 오류가 반환됨. cursor 기반 페이지네이션에서 첫 요청은 커서 없이 호출하는 것이 일반적이므로, 파라미터를 선택적으로 변경하고 미전달 시 현재 시각을 기준으로 최신 메시지를 조회하도록 수정.