### PR TITLE
fix: 블로그 ID 미검증으로 인한 TemplateInputException Sentry 오탐 수정

### DIFF
--- a/src/main/java/com/practicket/view/ViewController.java
+++ b/src/main/java/com/practicket/view/ViewController.java
@@ -3,11 +3,13 @@ package com.practicket.view;
 import com.practicket.ticket.application.TicketQueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Controller
@@ -46,6 +48,12 @@ public class ViewController {
 
     @GetMapping("/blog/{id}")
     public String blogContents(@PathVariable("id") String id, Model model) {
+        try {
+            long numId = Long.parseLong(id);
+            if (numId < 1) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
         return "blog/" + id;
     }
 


### PR DESCRIPTION
## 변경 사항
- `ViewController.blogContents()`에서 `{id}` 경로 변수를 양의 정수로만 허용하도록 검증 추가
- 숫자가 아닌 값(예: `phpinfo.php`) 요청 시 Thymeleaf 호출 전에 `404 Not Found` 응답 반환

## 배경
Sentry 이슈 PRACTICKET-2S: `GET /blog/{id}` 엔드포인트에서 `id` 경로 변수를 검증 없이 Thymeleaf 템플릿 이름으로 직접 사용하여, `/blog/phpinfo.php` 등 악성 스캔 요청이 들어올 때 `TemplateInputException`이 발생하고 Sentry에 캡처되는 문제. 블로그 템플릿은 `1.html`~`15.html`의 숫자 파일만 존재하므로, 숫자 외 입력은 유효하지 않은 요청으로 조기 거부해야 한다.