### PR TITLE
fix: PracticeService complete() 트랜잭션 분리로 HikariCP 커넥션 고갈 방지

### DIFF
--- a/src/main/java/com/practicket/practice/application/PracticeService.java
+++ b/src/main/java/com/practicket/practice/application/PracticeService.java
@@ -24,6 +24,7 @@ import com.practicket.practice.infra.redis.PracticeSessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -52,6 +53,7 @@ public class PracticeService {
         return new PracticeStartResponse(sessionId);
     }
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public PracticeCompleteResponse complete(ClientInfo clientInfo, PracticeResultRequest request) {
         ValidatedSession vs = sessionValidator.validate(clientInfo, request);
 


### PR DESCRIPTION
## 변경 사항
- `PracticeService.complete()`에 `@Transactional(propagation = Propagation.NOT_SUPPORTED)` 추가
- 클래스 레벨 `@Transactional`이 적용되던 `complete()`를 트랜잭션 없는 컨텍스트로 전환하여 `resultRepository.save()`, `rankCalculator.calculate()` 각각이 자체 단기 트랜잭션을 사용하도록 분리

## 배경
Sentry 이슈 PRACTICKET-52: `POST /api/practice/complete`에서 `CannotCreateTransactionException: Could not open JPA EntityManager for transaction` 발생.

클래스 레벨 `@Transactional`로 인해 `complete()` 전체—`resultRepository.save()` (쓰기) + `rankCalculator.calculate()` 내 집계 쿼리 2개(`countRecordsBetterThan`, `countRecordsInMonth`)—가 단일 트랜잭션으로 묶여 HikariCP 커넥션을 장시간 점유한다. 동시 요청이 늘어나면 풀이 고갈되고, 커넥션 대기 중인 스레드가 인터럽트되어 `InterruptedException` → `SQLException(HikariPool-1 - Interrupted during connection acquisition)` → `CannotCreateTransactionException` 연쇄가 발생한다.

`Propagation.NOT_SUPPORTED`를 지정하면 각 하위 작업이 SpringData 내장 `@Transactional`로 독립 실행되어 커넥션을 즉시 반환하므로 풀 고갈을 방지한다.