### PR TITLE
fix: TicketService 클래스 레벨 @Transactional 제거로 불필요한 DB 커넥션 획득 방지

### DIFF
--- a/src/main/java/com/practicket/ticket/application/TicketService.java
+++ b/src/main/java/com/practicket/ticket/application/TicketService.java
@@ -11,13 +11,11 @@ import com.practicket.ticket.dto.response.TicketRankResponseDto;
 import com.practicket.ticket.infra.redis.TicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class TicketService {
 


### PR DESCRIPTION
## 변경 사항
- `TicketService` 클래스 레벨의 `@Transactional` 어노테이션 및 관련 import 제거

## 배경
Sentry 이슈 PRACTICKET-3Q (`GET /api/rank`)에서 `CannotCreateTransactionException: Could not open JPA EntityManager for transaction`이 6회 발생.

`TicketService`의 모든 메서드(`getRankInfo`, `findAllSeats`, `createTicket` 등)는 `TicketRepository`(순수 Redis 기반, `StringRedisTemplate` 사용)만 호출하며 JPA DB 작업이 전혀 없다. 그럼에도 클래스 레벨 `@Transactional`로 인해 Spring이 모든 메서드 진입 시 HikariCP에서 DB 커넥션을 획득한다. 부하 상황에서 커넥션 대기 중 스레드가 인터럽트되면 `InterruptedException → SQLException → GenericJDBCException → CannotCreateTransactionException` 예외 체인이 발생한다. Redis만 사용하는 서비스에서 불필요한 DB 커넥션을 소비하지 않도록 `@Transactional`을 제거한다.