### PR TITLE
fix: 랭킹 조회 시 sort_buffer 초과로 발생하는 Out of sort memory 예외 수정

### DIFF
--- a/src/main/java/com/practicket/practice/infra/persistence/PracticeRankRepositoryImpl.java
+++ b/src/main/java/com/practicket/practice/infra/persistence/PracticeRankRepositoryImpl.java
@@ -22,20 +22,31 @@ public class PracticeRankRepositoryImpl implements PracticeRankRepository {
         LocalDateTime startDateTime = period.getStartDateTime();
 
         String cursorClause = cursorTotalDurationMs != null
-                ? "AND (total_duration_ms > :cursorTotalDurationMs OR (total_duration_ms = :cursorTotalDurationMs AND id > :cursorId)) "
+                ? "AND (pr.total_duration_ms > :cursorTotalDurationMs OR (pr.total_duration_ms = :cursorTotalDurationMs AND pr.id > :cursorId)) "
                 : "";
 
-        String sql = "SELECT id, nickname, total_duration_ms "
-                + "FROM ( "
-                + "    SELECT id, nickname, total_duration_ms, "
-                + "           ROW_NUMBER() OVER (PARTITION BY client_key ORDER BY total_duration_ms ASC, id ASC) AS rn "
+        // ROW_NUMBER() 윈도우 함수는 sort_buffer_size를 초과하는 대용량 정렬을 유발함.
+        // CTE + GROUP BY 방식으로 hash aggregation을 유도해 정렬 메모리 의존을 제거.
+        String sql = "WITH best_duration AS ( "
+                + "    SELECT client_key, MIN(total_duration_ms) AS min_duration "
                 + "    FROM practice_result "
-                + "    WHERE type = :type "
-                + "      AND started_at >= :startDateTime "
-                + ") ranked "
-                + "WHERE rn = 1 "
+                + "    WHERE type = :type AND started_at >= :startDateTime "
+                + "    GROUP BY client_key "
+                + "), "
+                + "best_row AS ( "
+                + "    SELECT MIN(pr.id) AS best_id "
+                + "    FROM practice_result pr "
+                + "    JOIN best_duration bd ON pr.client_key = bd.client_key "
+                + "      AND pr.total_duration_ms = bd.min_duration "
+                + "    WHERE pr.type = :type AND pr.started_at >= :startDateTime "
+                + "    GROUP BY pr.client_key "
+                + ") "
+                + "SELECT pr.id, pr.nickname, pr.total_duration_ms "
+                + "FROM practice_result pr "
+                + "JOIN best_row br ON pr.id = br.best_id "
+                + "WHERE 1=1 "
                 + cursorClause
-                + "ORDER BY total_duration_ms ASC, id ASC "
+                + "ORDER BY pr.total_duration_ms ASC, pr.id ASC "
                 + "LIMIT :limit";
 
         var query = em.createNativeQuery(sql)


### PR DESCRIPTION
## 변경 사항
- `PracticeRankRepositoryImpl.findRanking`의 `ROW_NUMBER() OVER (PARTITION BY client_key ORDER BY total_duration_ms ASC, id ASC)` 윈도우 함수를 CTE + GROUP BY 방식으로 교체
- 윈도우 함수 정렬을 두 단계 hash aggregation(최소 duration 집계 → 동점 시 최소 id 집계)으로 분리하여 MySQL sort_buffer_size 의존 제거

## 배경
Sentry 이슈 PRACTICKET-5G: `GET /api/practice/rank` 요청에서 `JpaSystemException → GenericJDBCException → SQLException: Out of sort memory, consider increasing server sort buffer size` 예외 발생.

`ROW_NUMBER() OVER (PARTITION BY client_key ORDER BY ...)` 윈도우 함수는 `WHERE type = ? AND started_at >= ?` 조건을 만족하는 전체 행을 MySQL이 메모리에서 정렬해야 한다. practice_result 테이블이 커질수록 정렬 대상 데이터가 서버의 `sort_buffer_size`를 초과해 예외로 이어진다.

CTE + GROUP BY로 교체하면 MySQL 옵티마이저가 sort-based 집계 대신 hash-based 집계를 선택할 수 있어 sort_buffer 의존 없이 클라이언트별 최적 행을 도출한다. 근본적인 해결을 위해서는 `(type, started_at, client_key, total_duration_ms, id)` 복합 인덱스 생성도 병행 검토 필요.