### PR TITLE
fix: MethodArgumentTypeMismatchException 전용 핸들러 추가로 잘못된 enum 파라미터 400 응답 처리

### DIFF
--- a/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
                 .orElse(errorCode.getMessage());
         ErrorResponse response = ErrorResponse.of(errorCode, message);
         return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handle(MethodArgumentTypeMismatchException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.PARAMETER_IS_NOT_VALID);
+        return ResponseEntity.status(400).body(response);
     }
 
     @ExceptionHandler(AsyncRequestNotUsableException.class)


### PR DESCRIPTION
## 변경 사항
- `GlobalExceptionHandler`에 `MethodArgumentTypeMismatchException` 전용 핸들러 추가
- 잘못된 enum 파라미터(예: `period=undefined`) 요청을 500 대신 400 `PARAMETER_IS_NOT_VALID`로 응답

## 배경
Sentry 이슈 PRACTICKET-4P: `GET /api/practice/rank?period=undefined` 요청 시 클라이언트가 JavaScript `undefined`를 문자열로 전송해 `MethodArgumentTypeMismatchException`이 발생했다. 기존 `GlobalExceptionHandler`에는 이 예외에 대한 전용 핸들러가 없어 catch-all `Exception` 핸들러로 빠지며 Sentry에 500 서버 에러로 8회 기록됐다(영향 사용자 3명). 이는 서버 버그가 아닌 클라이언트 입력 오류이므로 Sentry 캡처 없이 400으로 처리해야 한다.