### PR TITLE
fix: 랭킹 조회 중 DB 연결 단절 시 자동 재시도로 CommunicationsException 복구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'io.sentry:sentry-spring-boot-starter:6.34.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.retry:spring-retry'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/practicket/PracticketApplication.java
+++ b/src/main/java/com/practicket/PracticketApplication.java
@@ -3,7 +3,9 @@ package com.practicket;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @EnableJpaAuditing
 @SpringBootApplication
 public class PracticketApplication {

--- a/src/main/java/com/practicket/practice/application/PracticeService.java
+++ b/src/main/java/com/practicket/practice/application/PracticeService.java
@@ -22,7 +22,10 @@ import com.practicket.practice.infra.persistence.PracticeRankRepository;
 import com.practicket.practice.infra.persistence.PracticeResultRepository;
 import com.practicket.practice.infra.redis.PracticeSessionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,6 +75,7 @@ public class PracticeService {
         );
     }
 
+    @Retryable(retryFor = DataAccessResourceFailureException.class, maxAttempts = 2, backoff = @Backoff(delay = 300))
     @Transactional(readOnly = true)
     public PracticeRankResponse getRanking(PracticeType type, PeriodType period,
                                            Integer cursorTotalDurationMs, Long cursorId,


### PR DESCRIPTION
## 변경 사항
- `build.gradle`에 `spring-retry` 의존성 추가
- `PracticketApplication`에 `@EnableRetry` 추가로 Spring Retry AOP 활성화
- `PracticeService.getRanking()`에 `@Retryable(retryFor = DataAccessResourceFailureException.class, maxAttempts = 2, backoff = @Backoff(delay = 300))` 추가

## 배경
Sentry 이슈 PRACTICKET-4Y: `GET /api/practice/rank` 요청 처리 중 `DataAccessResourceFailureException → JDBCConnectionException → CommunicationsException → EOFException` 연쇄가 발생했습니다.

에러 메시지 "Can not read response from server. Expected to read 4 bytes, read 0 bytes before connection was unexpectedly lost" (마지막 통신 525ms 전)은 MySQL 서버가 쿼리 실행 도중 연결을 강제로 끊은 일시적 장애(transient failure)임을 나타냅니다. 유휴 커넥션 타임아웃(수십 분 단위)과 달리 525ms 만에 단절된 것은 DB 서버 순간 과부하나 네트워크 패킷 손실에 의한 것으로, HikariCP의 풀 크기·keepalive 설정만으로는 막을 수 없습니다.

랭킹 조회는 읽기 전용 멱등 쿼리이므로 재시도가 안전합니다. 300ms 대기 후 1회 재시도로 일시적 연결 단절에서 복구하여 사용자에게 오류 응답이 전달되는 빈도를 줄입니다.