### PR TITLE
fix: 비API 경로 필터 통과 시 InterruptedException을 ServletException으로 변환하여 Sentry 오탐 방지

### DIFF
--- a/src/main/java/com/practicket/common/filter/CustomRequestLoggingFilter.java
+++ b/src/main/java/com/practicket/common/filter/CustomRequestLoggingFilter.java
@@ -22,7 +22,15 @@ public class CustomRequestLoggingFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         
         if (!httpRequest.getRequestURI().startsWith("/api/")) {
-            chain.doFilter(request, response);
+            try {
+                chain.doFilter(request, response);
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new ServletException(e.getCause());
+                }
+                throw e;
+            }
             return;
         }
 


### PR DESCRIPTION
## 변경 사항
- `CustomRequestLoggingFilter.doFilter` 비API 경로 조기 반환 시 `chain.doFilter()` 호출을 try-catch로 감쌈
- `RuntimeException`의 원인이 `InterruptedException`인 경우 스레드 인터럽트 플래그를 복원하고 `ServletException`으로 변환하여 재던짐

## 배경
Sentry 이슈 PRACTICKET-53: `GET /actuator/health` 요청 처리 중 `Exceptions$ReactiveException: java.lang.InterruptedException`이 3회 발생.

`/actuator/health`는 `/api/`로 시작하지 않아 `CustomRequestLoggingFilter`의 조기 반환 경로(`chain.doFilter(request, response)`, line 25)로 처리된다. Kubernetes 헬스체크 프로브가 타임아웃되거나 취소될 때 Reactor가 스레드 인터럽트를 `ReactiveException(InterruptedException)` 형태의 RuntimeException으로 래핑하여 던지는데, 기존 필터에는 이를 처리하는 코드가 없어 예외가 Sentry에 unhandled 에러로 보고되었다. `InterruptedException`을 `ServletException`으로 변환함으로써 서블릿 컨테이너의 표준 오류 처리 흐름에 위임하고 Sentry 오탐을 방지한다.