### PR TITLE
fix: SSE 연결 후 대기열 미진입 상태에서 브로드캐스트 시 emitter 오삭제 방지

### DIFF
--- a/src/main/java/com/practicket/ticket/application/TicketQueueService.java
+++ b/src/main/java/com/practicket/ticket/application/TicketQueueService.java
@@ -113,8 +113,6 @@ public class TicketQueueService {
         }
         Long initialRank = queueRepository.getInitialRank(clientKey);
         if (initialRank == null) {
-            log.error("initial rank is null for clientKey: {}", clientKey);
-            emitterRepository.deleteByClientKey(clientKey);
             return;
         }
         String reservationToken = queueRepository.getToken(clientKey);


### PR DESCRIPTION
## 변경 사항
- `sendQueueInfoToClient`에서 `initialRank`가 null일 때 error 로그 출력 및 emitter 삭제 코드 제거
- 대기열에 아직 진입하지 않은 클라이언트는 다음 브로드캐스트 주기까지 건너뜀

## 배경
Sentry 이슈 PRACTICKET-35: `initial rank is null for clientKey: 563b85cb-9d9d-40ff-9355-7e9a01526e82`

SSE 접속(`GET /api/order`)과 대기열 등록(`POST /api/order`)은 별개의 API 요청이다. 클라이언트가 `GET`으로 emitter를 저장한 뒤 `POST`로 대기열에 진입하기 전 짧은 틈새에 `broadcastQueueInfo()` 스케줄러가 실행되면, Redis `ticket:queue:info` 해시에 `clientKey:initial-rank` 필드가 아직 없어 `getInitialRank()`가 null을 반환한다. 기존 코드는 이를 `log.error` + emitter 즉시 삭제로 처리해 유효한 SSE 연결을 잘못 종료시키고 Sentry에 오탐 ERROR를 발생시켰다. `initialRank == null`은 과도기적 정상 상태이므로 조용히 건너뛰어 다음 주기에 재처리하도록 수정한다.