### PR TITLE
fix: SSE 클라이언트 연결 해제 시 재활용된 response로 인한 IllegalStateException 처리

### DIFF
--- a/src/main/java/com/practicket/ticket/application/TicketQueueService.java
+++ b/src/main/java/com/practicket/ticket/application/TicketQueueService.java
@@ -131,7 +131,7 @@ public class TicketQueueService {
             if (response.isComplete()) {
                 emitterRepository.deleteByClientKey(clientKey);
             }
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             emitterRepository.deleteByClientKey(clientKey);
         }
     }


### PR DESCRIPTION
## 변경 사항
- `TicketQueueService.sendQueueInfoToClient()`의 catch 블록에 `IllegalStateException` 추가 (`IOException | IllegalStateException`)

## 배경
Sentry 이슈 PRACTICKET-59: `broadcastQueueInfo` 스케줄러가 1초마다 모든 SSE 에미터에 대기열 정보를 전송할 때, 클라이언트가 연결을 끊으면 Tomcat이 response 객체를 재활용(recycle)한다. 이 상태에서 `emitter.send()`를 호출하면 `IllegalStateException: The response object has been recycled and is no longer associated with this facade`가 발생한다. 기존 코드는 `IOException`만 catch하고 있어 `IllegalStateException`이 uncaught 예외로 전파되어 Sentry에 6회 리포트됐다. catch 범위를 넓혀 연결이 끊긴 에미터를 정상적으로 제거한다.