### PR TITLE
fix: MultipartException 전용 핸들러 추가로 불완전한 멀티파트 요청을 400으로 응답

### DIFF
--- a/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -49,4 +50,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AsyncRequestNotUsableException.class)
     public void handle(AsyncRequestNotUsableException e) {}
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handle(MultipartException e) {
+        log.warn("멀티파트 요청 파싱 실패: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.PARAMETER_IS_NOT_VALID;
+        ErrorResponse response = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
 }


### PR DESCRIPTION
## 변경 사항
- `GlobalExceptionHandler`에 `MultipartException` 전용 핸들러 추가
- 해당 예외 발생 시 `Sentry.captureException()` 호출 없이 400 Bad Request로 응답

## 배경
Sentry 이슈 PRACTICKET-57: `POST /practice/` 엔드포인트에서 `MultipartException: Failed to parse multipart servlet request` (원인: `MalformedStreamException: Stream ended unexpectedly`)가 28회 발생, 2명의 사용자에게 영향.

클라이언트가 멀티파트 스트림을 전송 도중 연결을 끊거나 불완전한 데이터를 보낼 경우 Spring의 `DispatcherServlet.checkMultipart()`에서 `MultipartException`이 발생한다. 기존에는 이 예외를 처리하는 전용 핸들러가 없어 `GlobalExceptionHandler`의 catch-all `handle(Exception e)`에 걸리면서 `Sentry.captureException()`이 명시 호출되어 서버 오류(500)로 보고되었다. 이는 클라이언트 측 원인에 해당하는 4xx 오류임에도 Sentry에 오탐으로 기록되는 문제다.