### PR TITLE
fix: PracticeService start() 불필요한 DB 트랜잭션 제거로 HikariCP 커넥션 고갈 방지

### DIFF
--- a/src/main/java/com/practicket/practice/application/PracticeService.java
+++ b/src/main/java/com/practicket/practice/application/PracticeService.java
@@ -24,6 +24,7 @@ import com.practicket.practice.infra.redis.PracticeSessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -43,6 +44,7 @@ public class PracticeService {
     private final PracticeSessionValidator sessionValidator;
     private final PracticeRankCalculator rankCalculator;
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public PracticeStartResponse start(ClientInfo clientInfo, PracticeType type) {
         if (clientInfo.getName() == null || clientInfo.getName().isBlank()) {
             throw new PracticeException(ErrorCode.NICKNAME_REQUIRED);


### PR DESCRIPTION
## 변경 사항
- `PracticeService.start()`에 `@Transactional(propagation = Propagation.NOT_SUPPORTED)` 추가

## 배경
Sentry 이슈 [PRACTICKET-5S](https://practicket.sentry.io/issues/7529347246/) 에서 `POST /api/practice/start` 호출 시 `CannotCreateTransactionException`이 발생했습니다. HikariPool-1이 `total=10, active=10, idle=0, waiting=191` 상태로 완전히 고갈된 것이 원인입니다.

`PracticeService` 클래스 레벨에 `@Transactional`이 선언되어 있어, Redis(`PracticeSessionRepository`)만 사용하는 `start()` 메서드도 JPA `EntityManager`를 생성하고 DB 커넥션을 획득합니다. 실제 DB 쿼리가 없음에도 커넥션을 점유하므로, 트래픽이 몰릴 경우 풀이 고갈됩니다. `NOT_SUPPORTED` 전파 수준을 적용하여 해당 메서드 호출 시 트랜잭션(및 DB 커넥션 획득)을 완전히 건너뜁니다.