### PR TITLE
fix: practice_result 테이블에 (type, started_at) 복합 인덱스 추가로 랭킹 조회 커넥션 고갈 방지

### DIFF
--- a/src/main/java/com/practicket/practice/domain/PracticeResult.java
+++ b/src/main/java/com/practicket/practice/domain/PracticeResult.java
@@ -11,6 +11,9 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@Table(name = "practice_result", indexes = {
+        @Index(name = "idx_practice_result_type_started_at", columnList = "type, started_at")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class PracticeResult {


### PR DESCRIPTION
## 변경 사항
- `PracticeResult` 엔티티에 `@Table(indexes = {...})` 선언 추가
- `(type, started_at)` 복합 인덱스(`idx_practice_result_type_started_at`) 정의

## 배경
Sentry 이슈 PRACTICKET-5D: `GET /api/practice/rank` 요청에서 HikariPool-1 커넥션 고갈 발생 (`total=10, active=10, idle=0, waiting=190`).

`PracticeRankRepositoryImpl.findRanking()`이 실행하는 윈도우 함수 쿼리는 `WHERE type = :type AND started_at >= :startDateTime` 조건으로 `practice_result` 테이블을 조회한다. 해당 컬럼에 인덱스가 없어 매 요청마다 전체 테이블 스캔이 발생하고, 쿼리가 오래 걸리는 동안 DB 커넥션이 점유된다. 동시 요청이 증가하면 기본 풀 크기(10)가 모두 소진되어 이후 요청이 30초 타임아웃 후 실패한다.