### PR TITLE
fix: ReactiveException으로 감싸진 InterruptedException 발생 시 인터럽트 플래그 복원 및 로그 레벨 WARN으로 변경

### DIFF
--- a/src/main/java/com/practicket/common/component/ProfanityValidator.java
+++ b/src/main/java/com/practicket/common/component/ProfanityValidator.java
@@ -22,6 +22,11 @@ public class ProfanityValidator {
         try {
             response = client.validate(text).block();
         } catch (Exception e) {
+            if (e.getCause() instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                log.warn("Profanity API 호출 중 스레드 인터럽트 발생 : text={}", text);
+                return;
+            }
             log.error("Profanity API 호출 실패 : 통과된 text={}, exception={}", text, e.getMessage(), e);
         }
         if (response != null && response.getIsProfanity() && response.getConfidence() > THRESHOLD) {


### PR DESCRIPTION
## 변경 사항
- `ProfanityValidator.validateProfanityText`의 catch 블록에서 `ReactiveException`의 원인이 `InterruptedException`인 경우를 별도 처리
- 인터럽트 발생 시 `Thread.currentThread().interrupt()`로 플래그 복원
- 스레드 인터럽트는 예상 가능한 상황(요청 취소 등)이므로 로그 레벨을 ERROR에서 WARN으로 낮춰 Sentry 오탐 방지

## 배경
`ProfanityValidator`에서 WebClient Reactive `Mono`에 `.block()`을 호출 중 요청 스레드가 인터럽트되면, Reactor가 `Exceptions$ReactiveException`으로 `InterruptedException`을 감싸 던진다. 기존 catch 블록은 이를 잡아 `log.error()`로 기록했지만 인터럽트 플래그를 복원하지 않고 Sentry가 ERROR 로그를 오류로 수집하는 문제가 있었다. Sentry 이슈 PRACTICKET-5Z (https://practicket.sentry.io/issues/7586704491/)에서 `POST /api/chat` 호출 중 `Exceptions$ReactiveException: java.lang.InterruptedException`이 반복 발생함이 확인되었다.