### PR TITLE
fix: SSE 연결 엔드포인트 ResponseEntity 래핑 제거로 HttpMediaTypeNotAcceptableException 해소

### DIFF
--- a/src/main/java/com/practicket/chat/application/ChatController.java
+++ b/src/main/java/com/practicket/chat/application/ChatController.java
@@ -41,8 +41,7 @@ public class ChatController {
     }
 
     @GetMapping(value = "/connection", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connectChat() {
-        SseEmitter emitter = chatService.createConnection();
-        return ResponseEntity.ok(emitter);
+    public SseEmitter connectChat() {
+        return chatService.createConnection();
     }
 }


### PR DESCRIPTION
## 변경 사항
- `GET /api/chat/connection` 핸들러의 반환 타입을 `ResponseEntity<SseEmitter>`에서 `SseEmitter`로 변경

## 배경
Sentry 이슈 PRACTICKET-61: `HttpMediaTypeNotAcceptableException: No acceptable representation` 에러가 `GET /api/chat/connection` 요청 시 반복 발생함.

Spring MVC는 `SseEmitter`를 `ResponseBodyEmitterReturnValueHandler`가 직접 반환할 때만 SSE 스트림으로 올바르게 처리한다. 그런데 `ResponseEntity<SseEmitter>`로 감싸면 `HttpEntityMethodProcessor`가 처리를 맡아 `SseEmitter`를 일반 메시지 컨버터(`writeWithMessageConverters`)로 직렬화하려 시도한다. `text/event-stream` 미디어 타입을 쓸 수 있는 컨버터가 존재하지 않으므로 `HttpMediaTypeNotAcceptableException`이 발생하고, `GlobalExceptionHandler`의 catch-all 핸들러를 통해 Sentry에 보고된다.