### PR TITLE
fix: SentryExceptionResolver 실행 순서를 LOWEST_PRECEDENCE로 조정하여 AuthException Sentry 오탐 방지

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,5 @@ management:
   endpoint:
     health:
       show-details: never
+sentry:
+  exception-resolver-order: 2147483647


### PR DESCRIPTION
## 변경 사항
- `application.yml`에 `sentry.exception-resolver-order: 2147483647` (Ordered.LOWEST_PRECEDENCE) 설정 추가

## 배경
Sentry 이슈 PRACTICKET-62 (`AuthException: 토큰이 존재하지 않습니다.`)가 프로덕션 환경에서 캡처되고 있음.

`AuthException`은 `GlobalException`을 상속하며, `GlobalExceptionHandler.handleGlobalException()`이 이를 올바르게 처리해 HTTP 404를 반환하고 `Sentry.captureException()`을 호출하지 않음. 그러나 `sentry-spring-boot-starter`가 자동 등록하는 `SentryExceptionResolver`가 기본적으로 `HIGHEST_PRECEDENCE` 순서로 등록되어, Spring의 `ExceptionHandlerExceptionResolver`보다 먼저 실행됨. 이로 인해 예상된 클라이언트 인증 오류(`AuthException`)가 Sentry에 오탐으로 수집되는 문제가 발생함.

`exception-resolver-order`를 `LOWEST_PRECEDENCE`로 설정하면 Spring의 `@RestControllerAdvice`가 먼저 예외를 처리하고, `SentryExceptionResolver`는 미처리 예외에 대해서만 동작함. 실제 서버 오류는 `GlobalExceptionHandler.handle(Exception.class)` 내의 명시적 `Sentry.captureException(e)` 호출을 통해 계속 Sentry에 전달됨.