### PR TITLE
fix: SSE 클라이언트 연결 해제 시 SocketException Sentry 오탐 방지

### DIFF
--- a/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.net.SocketException;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -49,4 +51,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AsyncRequestNotUsableException.class)
     public void handle(AsyncRequestNotUsableException e) {}
+
+    @ExceptionHandler(SocketException.class)
+    public void handle(SocketException e) {
+        log.debug("클라이언트 연결 종료={}", e.getMessage());
+    }
 }


### PR DESCRIPTION
## 변경 사항
- `GlobalExceptionHandler`에 `SocketException` 전용 핸들러 추가
- 클라이언트 연결 종료 시 Sentry 캡처 없이 DEBUG 레벨로만 로깅

## 배경
Sentry 이슈 PRACTICKET-6A: SSE(`/api/chat/connection`) 클라이언트가 연결을 끊으면 `SocketException: Connection reset`이 발생한다. 이 예외는 기존 범용 `Exception` 핸들러에 의해 `Sentry.captureException()`이 호출되어 노이즈 알림을 유발한다. SSE 클라이언트 연결 해제는 정상적인 동작이므로 `AsyncRequestNotUsableException`과 동일하게 Sentry 전송 없이 조용히 처리해야 한다.