### PR TITLE
fix: HikariCP keepalive-time 설정으로 유휴 커넥션 스테일 방지

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+  datasource:
+    hikari:
+      keepalive-time: 30000
   jackson:
     property-naming-strategy: SNAKE_CASE
 server:


### PR DESCRIPTION
## 변경 사항
- `application.yml`에 `spring.datasource.hikari.keepalive-time: 30000` 추가

## 배경
Sentry 이슈 PRACTICKET-65: `GET /api/practice/my-stats` 요청 처리 중 `JpaSystemException: Unable to rollback against JDBC Connection` 발생 (발생 횟수 4회, 영향 사용자 1명).

HikariCP 풀에 유휴 상태로 보관된 커넥션을 MySQL 서버가 `wait_timeout`으로 서버 측에서 먼저 닫는 경우, HikariCP는 해당 상태를 감지하지 못하고 스테일 커넥션을 요청 스레드에 반환한다. `PracticeService.getMyStats`가 트랜잭션을 시작해 이 커넥션으로 첫 쿼리를 실행하면 `SQLException: Connection is closed`가 발생하고, Spring이 롤백을 시도하지만 이미 닫힌 커넥션이라 `JpaSystemException`으로 전파된다.

`keepalive-time: 30000`(30초)을 설정하면 HikariCP가 풀 내 유휴 커넥션에 주기적으로 `Connection.isValid()` 핑을 보내 MySQL 서버 측 `wait_timeout` 도달 전에 커넥션 생존을 확인하므로 스테일 커넥션 반환이 방지된다.