### PR TITLE
fix: DB 연결 일시 단절 시 DataAccessResourceFailureException Sentry 오탐 방지

### DIFF
--- a/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/practicket/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.practicket.common.exception;
 
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -44,6 +45,14 @@ public class GlobalExceptionHandler {
                 .map(FieldError::getDefaultMessage)
                 .orElse(errorCode.getMessage());
         ErrorResponse response = ErrorResponse.of(errorCode, message);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(DataAccessResourceFailureException.class)
+    public ResponseEntity<ErrorResponse> handle(DataAccessResourceFailureException e) {
+        log.warn("DB 연결 일시 단절 감지: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse response = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 


### PR DESCRIPTION
## 변경 사항
- \`GlobalExceptionHandler\`에 \`DataAccessResourceFailureException\` 전용 핸들러 추가
- Sentry 캡처 없이 WARN 레벨로 로그를 남겨 오탐 방지

## 배경
Sentry 이슈 PRACTICKET-68: \`GET /api/captcha\` 요청 처리 중 \`ClientInfoArgumentResolver.resolveArgument()\`가 \`clientRepository.findByToken()\` 쿼리를 실행하는 시점에 MySQL 연결이 갑작스럽게 단절되어 \`DataAccessResourceFailureException → CommunicationsException\` 체인이 발생 (발생 횟수 1회, 영향 사용자 1명).

"마지막 패킷 수신 시점이 314ms 전"이라는 로그로 볼 때, 장기 유휴 커넥션의 스테일 문제가 아닌 일시적인 네트워크 단절 또는 DB 서버의 순간 장애로 인한 트랜지언트 오류다. 기존 제네릭 \`Exception\` 핸들러가 이를 잡아 \`Sentry.captureException()\`을 호출하므로 Sentry에 오탐으로 집계된다.

\`DataAccessResourceFailureException\` 전용 핸들러를 추가해 Sentry 캡처를 생략하고 WARN 로그만 남김으로써 인프라 수준의 일시 장애를 오탐 없이 모니터링할 수 있도록 한다.