### PR TITLE
fix: 애플리케이션 종료 시 ShedLock 잠금 해제 중 LockException 수정

### DIFF
--- a/src/main/java/com/practicket/config/RedisConfig.java
+++ b/src/main/java/com/practicket/config/RedisConfig.java
@@ -1,9 +1,12 @@
 package com.practicket.config;
 
 import com.practicket.chat.component.ChatMessageSubscriber;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -13,6 +16,20 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    @Bean
+    public static BeanPostProcessor lettuceConnectionFactoryLifecycleConfigurer() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof LettuceConnectionFactory factory) {
+                    // SchedulerConfig SmartLifecycle(MAX_VALUE)보다 나중에 종료되도록 phase를 낮춤
+                    factory.setPhase(Integer.MAX_VALUE - 100);
+                }
+                return bean;
+            }
+        };
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {

--- a/src/main/java/com/practicket/config/SchedulerConfig.java
+++ b/src/main/java/com/practicket/config/SchedulerConfig.java
@@ -3,6 +3,7 @@ package com.practicket.config;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -14,14 +15,44 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @Configuration
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "30s")
-public class SchedulerConfig implements SchedulingConfigurer {
+public class SchedulerConfig implements SchedulingConfigurer, SmartLifecycle {
+
+    private ThreadPoolTaskScheduler taskScheduler;
+    private volatile boolean running = false;
+
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler = new ThreadPoolTaskScheduler();
         taskScheduler.setPoolSize(10);
         taskScheduler.setThreadNamePrefix("Time-Reset-Thread-");
+        taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+        taskScheduler.setAwaitTerminationSeconds(30);
         taskScheduler.initialize();
         taskRegistrar.setTaskScheduler(taskScheduler);
+    }
+
+    @Override
+    public void start() {
+        running = true;
+    }
+
+    @Override
+    public void stop() {
+        running = false;
+        if (taskScheduler != null) {
+            taskScheduler.shutdown();
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public int getPhase() {
+        // LettuceConnectionFactory(MAX_VALUE - 100)보다 먼저 종료되어 ShedLock 잠금 해제 후 Redis가 닫히도록 보장
+        return Integer.MAX_VALUE;
     }
 
     @Bean


### PR DESCRIPTION
## 변경 사항
- `SchedulerConfig`에 `SmartLifecycle` 구현 추가 (phase = `Integer.MAX_VALUE`): 종료 시 실행 중인 스케줄러 태스크가 완료될 때까지 대기 (`waitForTasksToCompleteOnShutdown=true`, 최대 30초)
- `RedisConfig`에 `BeanPostProcessor` 추가: `LettuceConnectionFactory`의 lifecycle phase를 `Integer.MAX_VALUE - 100`으로 낮춰 스케줄러 종료 이후에 Redis 연결이 닫히도록 보장

## 배경
Sentry 이슈 [PRACTICKET-56](https://practicket.sentry.io/issues/7468100429/): `addVirtualUserOnQueue` 실행 중 애플리케이션이 종료될 때 `LettuceConnectionFactory`가 먼저 중단되고, ShedLock이 Redis에서 분산 잠금을 해제하려 할 때 `IllegalStateException: LettuceConnectionFactory has been STOPPED` → `LockException: Can not remove node`가 연쇄 발생하는 문제.

기본적으로 `LettuceConnectionFactory`는 `SmartLifecycle`(phase = `Integer.MAX_VALUE`)이라 Spring 종료 시 가장 먼저 멈추지만, `ThreadPoolTaskScheduler`는 일반 `DisposableBean`이라 이후에 종료된다. 이 순서 역전이 근본 원인이며, 두 빈의 lifecycle phase를 조정해 스케줄러 → Redis 순으로 종료되도록 수정했다.