### PR TITLE
fix: SSE 콜백의 완료 호출 제거

### DIFF
--- a/src/main/java/com/practicket/chat/application/ChatService.java
+++ b/src/main/java/com/practicket/chat/application/ChatService.java
@@ -14,7 +14,6 @@ import com.practicket.common.exception.ErrorCode;
 import com.practicket.common.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
@@ -23,7 +22,6 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ChatService {
 

--- a/src/main/java/com/practicket/chat/component/ChatConnectionManager.java
+++ b/src/main/java/com/practicket/chat/component/ChatConnectionManager.java
@@ -19,6 +19,9 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class ChatConnectionManager {
 
+    /** 무한(0)이면 얼어붙은 연결을 아무도 못 걷어낸다. 만료돼도 브라우저가 곧바로 다시 붙는다. */
+    private static final long EMITTER_TIMEOUT_MS = 30 * 60 * 1000L;
+
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     private final String EVENT_NAME = "chat";
@@ -27,7 +30,7 @@ public class ChatConnectionManager {
     private final ChatParticipantCounter participantCounter;
 
     public SseEmitter save(String key) {
-        SseEmitter emitter = new SseEmitter(0L);
+        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
         registerCallbacks(key, emitter);
         emitters.put(key, emitter);
         participantCounter.report(emitters.size());
@@ -35,8 +38,8 @@ public class ChatConnectionManager {
     }
 
     /**
-     * 실제로 지워졌을 때만 알린다. onTimeout/onError 가 complete() 를 부르면 onCompletion 이 또 돌아
-     * 한 번의 종료에 두 번 들어오는데, 그때마다 알리면 전 파드가 헛되이 SSE 를 다시 쏜다.
+     * 종료 경로가 여럿이라 같은 키로 두 번 들어올 수 있다. 실제로 지워졌을 때만 알린다 —
+     * 헛되이 알리면 전 파드가 모든 연결에 SSE 를 다시 쏜다.
      */
     public void deleteByKey(String key) {
         if (emitters.remove(key) != null) {
@@ -80,25 +83,26 @@ public class ChatConnectionManager {
         }
     }
 
+    /** 전송 실패로 걷어낸 만큼 인원도 줄어든다. 안 알리면 Redis 에 옛 숫자가 남는다. */
     public void broadcast(ChatResponseDto data) {
+        List<String> dead = new ArrayList<>();
         for (Map.Entry<String, SseEmitter> entry : emitters.entrySet()) {
             try {
                 entry.getValue().send(SseEmitter.event().name(EVENT_NAME).data(data));
             } catch (Exception e) {
-                emitters.remove(entry.getKey());
+                dead.add(entry.getKey());
             }
         }
+        if (dead.isEmpty()) {
+            return;
+        }
+        dead.forEach(emitters::remove);
+        participantCounter.report(emitters.size());
     }
 
     public void registerCallbacks(String key, SseEmitter emitter) {
         emitter.onCompletion(() -> deleteByKey(key));
-        emitter.onTimeout(() -> {
-            emitter.complete();
-            deleteByKey(key);
-        });
-        emitter.onError((error) -> {
-            emitter.complete();
-            deleteByKey(key);
-        });
+        emitter.onTimeout(() -> deleteByKey(key));
+        emitter.onError((error) -> deleteByKey(key));
     }
 }

--- a/src/main/java/com/practicket/config/RedisConfig.java
+++ b/src/main/java/com/practicket/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.practicket.config;
 import com.practicket.captcha.component.CaptchaStatInvalidationSubscriber;
 import com.practicket.chat.component.ChatMessageSubscriber;
 import com.practicket.chat.component.ChatParticipantSubscriber;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,9 +13,14 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+@Slf4j
 @Configuration
 public class RedisConfig {
+
+    private static final int LISTENER_POOL_SIZE = 8;
+    private static final int LISTENER_QUEUE_CAPACITY = 1_000;
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
@@ -55,6 +61,25 @@ public class RedisConfig {
         return new MessageListenerAdapter(subscriber, "onMessage");
     }
 
+    /**
+     * 지정하지 않으면 컨테이너가 메시지마다 스레드를 새로 만들고 재사용하지 않는다.
+     * 전송이 막히면 그 스레드가 회수되지 않아 무한히 쌓인다(2026-08-24 사고).
+     * 넘칠 때는 버린다 — 구독 스레드를 붙잡거나 예외를 흘리면 pub/sub 전체가 멈춘다.
+     */
+    @Bean
+    public ThreadPoolTaskExecutor listenerExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(LISTENER_POOL_SIZE);
+        executor.setMaxPoolSize(LISTENER_POOL_SIZE);
+        executor.setQueueCapacity(LISTENER_QUEUE_CAPACITY);
+        executor.setThreadNamePrefix("redis-listener-");
+        executor.setRejectedExecutionHandler((task, pool) ->
+                log.warn("Redis 리스너 대기줄이 가득 차 메시지를 버렸다 — 활성 {}, 대기 {}",
+                        pool.getActiveCount(), pool.getQueue().size()));
+        executor.initialize();
+        return executor;
+    }
+
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory factory,
@@ -66,6 +91,7 @@ public class RedisConfig {
             ChannelTopic captchaStatTopic) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(factory);
+        container.setTaskExecutor(listenerExecutor());
         container.addMessageListener(chatListenerAdapter, chatTopic);
         container.addMessageListener(chatParticipantListenerAdapter, chatParticipantTopic);
         container.addMessageListener(captchaStatListenerAdapter, captchaStatTopic);

--- a/src/main/java/com/practicket/ticket/application/TicketQueueService.java
+++ b/src/main/java/com/practicket/ticket/application/TicketQueueService.java
@@ -32,6 +32,9 @@ public class TicketQueueService {
     private final TicketTokenRepository tokenRepository;
     private final ThreadPoolTaskExecutor ticketTaskExecutor;
 
+    /** 무한(0)이면 얼어붙은 연결을 아무도 못 걷어낸다. 만료돼도 브라우저가 곧바로 다시 붙는다. */
+    private static final long EMITTER_TIMEOUT_MS = 30 * 60 * 1000L;
+
     private static final int QUEUE_THROUGHPUT = 10;
     private static final int MAX_CONCURRENT_RESERVATIONS = 5000;
     private static final String WAITING_QUEUE_NAME = "waiting-order";
@@ -45,17 +48,13 @@ public class TicketQueueService {
     }
 
     public SseEmitter saveEmitter(String key) {
-        SseEmitter emitter = new SseEmitter(0L);
+        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
         emitterRepository.save(key, emitter);
+        // 콜백 안에서 complete() 를 부르면 안 된다. 컨테이너가 비동기요청 락을 쥔 채 부르는 자리라,
+        // 거기서 emitter 모니터를 요구하면 방송 스레드와 락 순서가 엇갈려 서로 영구 대기한다.
         emitter.onCompletion(() -> emitterRepository.deleteByClientKey(key));
-        emitter.onTimeout(() -> {
-            emitter.complete();
-            emitterRepository.deleteByClientKey(key);
-        });
-        emitter.onError((error) -> {
-            emitter.complete();
-            emitterRepository.deleteByClientKey(key);
-        });
+        emitter.onTimeout(() -> emitterRepository.deleteByClientKey(key));
+        emitter.onError((error) -> emitterRepository.deleteByClientKey(key));
         return emitter;
     }
 


### PR DESCRIPTION
## 변경 사항

- `onError`/`onTimeout` 콜백 안의 `emitter.complete()` 제거 (채팅·대기열)
- emitter 수명을 무한(`0L`)에서 30분으로 변경
- `broadcast` 가 전송 실패한 연결을 걷어낼 때 인원 보고를 함께 하도록 교정
- Redis 리스너 컨테이너에 스레드 정원 8 · 대기줄 1000 지정
- `ChatService` 의 불필요한 클래스 레벨 `@Transactional` 제거

## 배경

운영 파드 한 대가 **25.9시간째 영구 정지(데드락)** 상태였다. 증상 세 가지가 모두 같은 원인이었다.

| 사용자가 본 것 | 실제 |
|---|---|
| "296명 접속중" | 실제 1~2명. 나머지는 죽은 파드의 유령 연결 |
| "0명 접속중" | 죽은 파드에 붙어 SSE 응답 헤더조차 못 받음 |
| "채팅이 안 써짐" | 전송·저장은 정상. 화면은 서버 에코로만 그리는데 그게 안 옴 |

### 락 순환

`onError`/`onTimeout` 은 컨테이너가 **비동기요청 락을 쥔 채** 부르는 자리다. 거기서 `complete()` 를 부르면 **emitter 모니터**를 요구하게 되어 락 순서가 뒤집힌다.

```
톰캣 스레드   : ReentrantLock 보유  → SseEmitter 모니터 대기  (ChatConnectionManager.java:100)
리스너 스레드 : SseEmitter 모니터 보유 → ReentrantLock 대기   (ChatConnectionManager.java:76)
```

이 호출은 애초에 불필요하다. 타임아웃·에러도 컨테이너가 완료 처리하고 `onCompletion` 을 부른다. javadoc 도 "컨테이너 관련 이벤트 이후에는 쓰지 말라"고 명시한다.

### 왜 지금 터졌나

`cb9fb9a`(2026-08-04)에서 인원 집계를 **파드 내부 호출 → Redis pub/sub** 으로 옮겼다. 그 전에는 끊김을 처리하던 스레드가 자기가 방송해 재진입이라 순환이 성립할 수 없었다. `4b7f709`(2026-08-17)에서 패널을 열고 닫을 때마다 연결하도록 바뀌며 빈도가 크게 올랐다.

## 검증

로컬에서 코드에 지연을 심지 않고 실제 조건만으로 재현한 뒤, 같은 부하로 회귀 검증했다.

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| 부하 종료 30초 후 접속자 수 | **6,902 (굳음)** | **0** |
| SSE 연결 수립 | 실패 | 정상 |
| 리스너 스레드 | **2,366** | **2** |
| 전체 스레드 | 2,500 | 89 |

- 채팅 접속·해제 **7,818회** 통과
- 대기열 접속·해제 **6,780회** 통과
- 리스너 스레드가 정확히 8에서 상한
- `./gradlew test` 통과

> 대기열은 방송 스레드가 하나뿐이라 재현하지 못했다. 다만 **코드가 동일**하고 메커니즘은 채팅에서 증명됐으므로 함께 고쳤다.

## 참고

- 조사 기록: `docs/issue/chat-sse-deadlock-2026-08-24.md`
- 파생 이슈(미수정): `docs/issue/sse-socket-leak-2026-08-24.md` — 대기열 SSE 소켓 누수